### PR TITLE
API for declaring child cards

### DIFF
--- a/dist/conductor.js-0.1.0.js
+++ b/dist/conductor.js-0.1.0.js
@@ -1388,10 +1388,97 @@ define("oasis",
         Conductor.Oasis.portFor('data').send('updateData', { bucket: name, object: hash });
       },
 
+      /**
+       A card can contain other cards.
+
+       `childCards` is an array of objects describing the differents cards. The accepted attributes are:
+       * `url` {String} the url of the card
+       * `id` {String} a unique identifier for this instance (per type)
+       * `options` {Object} Options passed to `Conductor.load` (optional)
+       * `data` {Object} passed to `Conductor.loadData`
+
+       Example:
+
+          Conductor.card({
+            childCards: [
+              { url: '../cards/survey', id: 1 , options: {}, data: '' }
+            ]
+          });
+
+       Any `Conductor.Oasis.Service` needed for a child card can be simply declared with the `services` attribute
+       A card can contain other cards.
+
+       Example:
+
+          Conductor.card({
+            services: {
+              survey: SurveyService
+            },
+            childCards: [
+              {url: 'survey', id: 1 , options: {capabilities: ['survey']} }
+            ]
+          });
+
+       `loadDataForChildCards` can be defined when a child card needs data passed to the parent card.
+
+       Once `initializeChildCards` has been called, the loaded card can be accessed through the `childCards` attribute.
+
+       Example:
+
+          var card = Conductor.card({
+            childCards: [
+              { url: '../cards/survey', id: 1 , options: {}, data: '' }
+            ]
+          });
+
+
+          // After `initializeChildCards` has been called
+          var surveyCard = card.childCards[0].card;
+
+        The easy way to add a child card to the DOM is through the `initializeDOM` hook from the `render` service.
+       */
+      initializeChildCards: function( data ) {
+        var prop;
+
+        if(this.childCards) {
+          this.conductor = new Conductor();
+          this.conductor.services.xhr = Conductor.MultiplexService.extend({ upstream: this.consumers.xhr });
+
+          // A child card may not need new services
+          if( this.services ) {
+            for( prop in this.services) {
+              this.conductor.services[prop] = this.services[prop];
+            }
+          }
+
+          // Hook if you want to initialize cards that are not yet instantiated
+          if( this.loadDataForChildCards ) {
+            this.loadDataForChildCards( data );
+          }
+
+          for( prop in this.childCards ) {
+            var childCardOptions = this.childCards[prop];
+
+            this.conductor.loadData(
+              childCardOptions.url,
+              childCardOptions.id,
+              childCardOptions.data
+            );
+
+            childCardOptions.card = this.conductor.load( childCardOptions.url, childCardOptions.id, childCardOptions.options );
+          }
+        }
+      },
+
       activateWhen: function(dataPromise, otherPromises) {
         var card = this;
 
         return RSVP.all([dataPromise].concat(otherPromises)).then(function(resolutions) {
+          // Need to think if this called at the right place/time
+          // My assumption for the moment is that
+          // we don't rely on some initializations done in activate
+          if (card.initializeChildCards) { card.initializeChildCards(resolutions[0]); }
+
           if (card.activate) { card.activate(resolutions[0]); }
         });
       }
@@ -1681,8 +1768,13 @@ define("oasis",
 
   Conductor.renderConsumer = function(promise, card) {
     var options = Object.create(card.options);
+    var domInitialized = false;
 
     options.events.render = function(args) {
+      if(!domInitialized && card.initializeDOM) {
+        domInitialized = true;
+        card.initializeDOM();
+      }
       card.render.apply(card, args);
     };
 

--- a/example/cards/ad-playlist/card.js
+++ b/example/cards/ad-playlist/card.js
@@ -30,22 +30,33 @@ var card = Conductor.card({
     })
   },
 
+  childCards: [
+    {url: AdCardUrl,  id: '1', options: { capabilities: ['video', 'survey'] } }
+  ],
+  services: {
+    survey: SurveyService,
+    video: VideoService
+  },
+
   activate: function (data) {
-    this.conductor = new Conductor();
+    // this may need to go in loadDataForChildCards
+    this.adIds = Object.keys(data);
+  },
+
+  loadDataForChildCards: function( data) {
+    this.childCards[0].data = data[ this.childCards[0].id ];
 
     for (var prop in data) {
       if ( ! data.hasOwnProperty(prop)) { continue; }
-
       this.conductor.loadData(AdCardUrl, prop, data[prop]);
     }
-    this.adIds = Object.keys(data);
+  },
 
-    this.conductor.services.xhr = Conductor.MultiplexService.extend({ upstream: this.consumers.xhr });
-    this.conductor.services.survey = SurveyService;
-    this.conductor.services.video = VideoService;
-
+  initializeDOM: function() {
     this.setupDom();
-    this.nextAd(false);
+    this.videoAdCard = this.childCards[0].card;
+    this.videoAdCard.appendTo($('#ads')[0]);
+    this.videoAdCard.render('video', this.getVideoDimensions());
   },
 
   render: function (intent, dimensions) {
@@ -101,7 +112,7 @@ var card = Conductor.card({
 
   nextAd: function (autoplay) {
     if (typeof this.currentAdIndex === 'undefined') {
-      this.currentAdIndex = 0;
+      this.currentAdIndex = 1;
     } else {
       this.currentAdIndex = ((this.currentAdIndex + 1) % this.adIds.length);
     }

--- a/example/cards/ad/card.js
+++ b/example/cards/ad/card.js
@@ -39,21 +39,31 @@ var card = Conductor.card({
     })
   },
 
-  activate: function (data) {
-    var conductor,
-        videoCard,
-        videoCardId = data.videoId,
-        surveyCard;
+  childCards: [
+    {url: '../cards/video/card.js', options: { capabilities: ['video']}},
+    {url: '../cards/survey/card.js', options: { capabilities: ['survey']}}
+  ],
+  services: {
+    video: VideoService,
+    survey: SurveyService
+  },
 
+  loadDataForChildCards: function(data) {
+    var videoCardOptions = this.childCards[0],
+        surveyCardOptions = this.childCards[1];
+
+    videoCardOptions.id = data.videoId;
+    videoCardOptions.data = { videoId: data.videoId };
+
+    surveyCardOptions.id = data.videoId;
+  },
+
+  activate: function (data) {
     Conductor.Oasis.RSVP.EventTarget.mixin(this);
 
-    this.conductor = new Conductor();
-    this.conductor.services.xhr = Conductor.MultiplexService.extend({ upstream: this.consumers.xhr });
-    this.conductor.services.video = VideoService;
-    this.conductor.services.survey = SurveyService;
-
     this.videoId = data.videoId;
-    this.loadCards();
+    this.videoCard = this.childCards[0].card;
+    this.surveyCard = this.childCards[1].card;
   },
 
   render: function (intent, _dimensions) {
@@ -92,27 +102,9 @@ var card = Conductor.card({
     }
   },
 
-  loadCards: function () {
-    this.loadVideoCard();
-    this.loadSurveyCard();
-  },
-
-  loadVideoCard: function () {
-    var videoCard,
-        videoCardUrl = '../cards/video/card.js';
-
-    this.conductor.loadData(videoCardUrl, this.videoId, { videoId: this.videoId});
-
-    videoCard = this.videoCard = this.conductor.load(videoCardUrl, this.videoId, { capabilities: ['video']});
-    videoCard.appendTo(document.body);
-  },
-
-  loadSurveyCard: function () {
-    var surveyCard,
-        surveyCardUrl = '../cards/survey/card.js';
-
-    surveyCard = this.surveyCard = this.conductor.load(surveyCardUrl, this.videoId, { capabilities: ['survey']});
-    surveyCard.appendTo(document.body);
+  initializeDOM: function () {
+    this.videoCard.appendTo(document.body);
+    this.surveyCard.appendTo(document.body);
   },
 
   getDimensions: function () {

--- a/example/cards/superbowl/card.js
+++ b/example/cards/superbowl/card.js
@@ -35,22 +35,25 @@ var AdPlaylistService = Conductor.Oasis.Service.extend({
 });
 
 var card = Conductor.card({
-  activate: function(data) {
-    this.conductor = new Conductor();
+  childCards: [
+    {url: SlotMachineCardUrl,  id: '1', options: { capabilities: ['slotMachine']},  data: { coins: 0, insertCoinsLabel: 'Watch another ad' } },
+    {url: AdPlaylistCardUrl,   id: '1', options: { capabilities: ['adPlaylist']} }
+  ],
+  services: {
+    adPlaylist: AdPlaylistService,
+    slotMachine: SlotMachineService
+  },
 
-    this.conductor.services.xhr = Conductor.MultiplexService.extend({ upstream: this.consumers.xhr });
-    this.conductor.services.adPlaylist = AdPlaylistService;
-    this.conductor.services.slotMachine = SlotMachineService;
+  loadDataForChildCards: function( data) {
+    this.childCards[1].data = data;
+  },
 
-    this.conductor.loadData(AdPlaylistCardUrl, '1', data);
-    this.conductor.loadData(SlotMachineCardUrl, '1', { coins: 0, insertCoinsLabel: 'Watch another ad' });
-
-    this.adPlaylistCard = this.conductor.load(AdPlaylistCardUrl, 1, { capabilities: ['adPlaylist']});
-    this.slotMachineCard = this.conductor.load(SlotMachineCardUrl, 1, { capabilities: ['slotMachine']});
-
+  initializeDOM: function() {
     $('body').html('<div id="playlist"></div><div id="slot_machine"></div>');
+    this.adPlaylistCard = this.childCards[1].card;
     this.adPlaylistCard.appendTo($('#playlist')[0]);
     this.adPlaylistCard.render('thumbnail', { width: 600, height: 400 });
+    this.slotMachineCard = this.childCards[0].card;
     this.slotMachineCard.appendTo($('#slot_machine')[0]);
     this.slotMachineCard.render('small', { width: 600, height: 200 });
     $('#slot_machine').hide();

--- a/lib/conductor/card.js
+++ b/lib/conductor/card.js
@@ -76,10 +76,97 @@
       Conductor.Oasis.portFor('data').send('updateData', { bucket: name, object: hash });
     },
 
+    /**
+     A card can contain other cards.
+
+     `childCards` is an array of objects describing the differents cards. The accepted attributes are:
+     * `url` {String} the url of the card
+     * `id` {String} a unique identifier for this instance (per type)
+     * `options` {Object} Options passed to `Conductor.load` (optional)
+     * `data` {Object} passed to `Conductor.loadData`
+
+     Example:
+
+        Conductor.card({
+          childCards: [
+            { url: '../cards/survey', id: 1 , options: {}, data: '' }
+          ]
+        });
+
+     Any `Conductor.Oasis.Service` needed for a child card can be simply declared with the `services` attribute
+     A card can contain other cards.
+
+     Example:
+
+        Conductor.card({
+          services: {
+            survey: SurveyService
+          },
+          childCards: [
+            {url: 'survey', id: 1 , options: {capabilities: ['survey']} }
+          ]
+        });
+
+     `loadDataForChildCards` can be defined when a child card needs data passed to the parent card.
+
+     Once `initializeChildCards` has been called, the loaded card can be accessed through the `childCards` attribute.
+
+     Example:
+
+        var card = Conductor.card({
+          childCards: [
+            { url: '../cards/survey', id: 1 , options: {}, data: '' }
+          ]
+        });
+
+
+        // After `initializeChildCards` has been called
+        var surveyCard = card.childCards[0].card;
+
+      The easy way to add a child card to the DOM is through the `initializeDOM` hook from the `render` service.
+     */
+    initializeChildCards: function( data ) {
+      var prop;
+
+      if(this.childCards) {
+        this.conductor = new Conductor();
+        this.conductor.services.xhr = Conductor.MultiplexService.extend({ upstream: this.consumers.xhr });
+
+        // A child card may not need new services
+        if( this.services ) {
+          for( prop in this.services) {
+            this.conductor.services[prop] = this.services[prop];
+          }
+        }
+
+        // Hook if you want to initialize cards that are not yet instantiated
+        if( this.loadDataForChildCards ) {
+          this.loadDataForChildCards( data );
+        }
+
+        for( prop in this.childCards ) {
+          var childCardOptions = this.childCards[prop];
+
+          this.conductor.loadData(
+            childCardOptions.url,
+            childCardOptions.id,
+            childCardOptions.data
+          );
+
+          childCardOptions.card = this.conductor.load( childCardOptions.url, childCardOptions.id, childCardOptions.options );
+        }
+      }
+    },
+
     activateWhen: function(dataPromise, otherPromises) {
       var card = this;
 
       return RSVP.all([dataPromise].concat(otherPromises)).then(function(resolutions) {
+        // Need to think if this called at the right place/time
+        // My assumption for the moment is that
+        // we don't rely on some initializations done in activate
+        if (card.initializeChildCards) { card.initializeChildCards(resolutions[0]); }
+
         if (card.activate) { card.activate(resolutions[0]); }
       });
     }

--- a/lib/consumers/render_consumer.js
+++ b/lib/consumers/render_consumer.js
@@ -1,7 +1,12 @@
 Conductor.renderConsumer = function(promise, card) {
   var options = Object.create(card.options);
+  var domInitialized = false;
 
   options.events.render = function(args) {
+    if(!domInitialized && card.initializeDOM) {
+      domInitialized = true;
+      card.initializeDOM();
+    }
     card.render.apply(card, args);
   };
 

--- a/test/fixtures/child/config_data_child_card.js
+++ b/test/fixtures/child/config_data_child_card.js
@@ -1,0 +1,7 @@
+var card = Conductor.card({
+  activate: function(data) {
+    ok(true, "child card activated");
+    equal( data, 'food for card', "A child card is initialized with data");
+    start();
+  }
+});

--- a/test/fixtures/child/config_data_parent_card.js
+++ b/test/fixtures/child/config_data_parent_card.js
@@ -1,0 +1,8 @@
+Conductor.card({
+  childCards: [
+    {url: '/test/fixtures/child/config_data_child_card.js', id: 1, options: {capabilities: ['assertion']}, data: 'food for card'}
+  ],
+  activate: function() {
+    ok(true, "parent card activated");
+  }
+});

--- a/test/fixtures/child/custom_data_parent_card.js
+++ b/test/fixtures/child/custom_data_parent_card.js
@@ -1,0 +1,11 @@
+Conductor.card({
+  childCards: [
+    {url: '/test/fixtures/child/no_service_card.js', id: 1, options: {capabilities: ['assertion']}}
+  ],
+  loadDataForChildCards: function(data) {
+    equal( data, "food for cards", "");
+  },
+  activate: function() {
+    ok(true, "parent card activated");
+  }
+});

--- a/test/fixtures/child/no_custom_data_parent_card.js
+++ b/test/fixtures/child/no_custom_data_parent_card.js
@@ -1,0 +1,9 @@
+Conductor.card({
+  childCards: [
+    {url: '/test/fixtures/child/no_service_card.js', id: 1, options: {capabilities: ['assertion']}}
+  ],
+  activate: function() {
+    ok(true, "parent card activated");
+    equal( this.loadDataForChildCards, undefined, "No custom data for child cards");
+  }
+});

--- a/test/fixtures/child/no_service_card.js
+++ b/test/fixtures/child/no_service_card.js
@@ -1,0 +1,6 @@
+var card = Conductor.card({
+  activate: function(data) {
+    ok(true, "child card activated");
+    start();
+  }
+});

--- a/test/fixtures/child/no_service_parent_card.js
+++ b/test/fixtures/child/no_service_parent_card.js
@@ -1,0 +1,12 @@
+Conductor.card({
+  childCards: [
+    {url: '/test/fixtures/child/no_service_card.js', id: 1, options: {capabilities: ['assertion']}}
+  ],
+  activate: function() {
+    var customServices = Object.keys( this.conductor.services );
+
+    ok(true, "parent card activated");
+    equal( customServices.length, 1, "only one custom service");
+    equal( customServices[0], 'xhr', "No custom services added on the parent card beside the multiplexed xhr service");
+  }
+});

--- a/test/fixtures/child/require_child_card.js
+++ b/test/fixtures/child/require_child_card.js
@@ -1,0 +1,7 @@
+Conductor.require("/test/fixtures/alert.js");
+
+Conductor.card({
+  activate: function() {
+    start();
+  }
+});

--- a/test/fixtures/child/require_parent_card.js
+++ b/test/fixtures/child/require_parent_card.js
@@ -1,0 +1,5 @@
+Conductor.card({
+  childCards: [
+    {url: '/test/fixtures/child/require_child_card.js', id: 1, options: {capabilities: ['assertion']}}
+  ]
+});

--- a/test/fixtures/child/service_parent_card.js
+++ b/test/fixtures/child/service_parent_card.js
@@ -1,0 +1,17 @@
+var CustomService = Conductor.Oasis.Service.extend({
+  events: {
+    result: function (result) {
+      start();
+      equal(result,"success", "Custom Service received message");
+    }
+  }
+});
+
+Conductor.card({
+  childCards: [
+    {url: '/test/fixtures/custom_consumer_card.js', id: 1, options: {capabilities: ['custom']}}
+  ],
+  services: {
+    custom: CustomService
+  }
+});

--- a/test/fixtures/render/initialize_dom_card.js
+++ b/test/fixtures/render/initialize_dom_card.js
@@ -1,0 +1,12 @@
+var rendered = false;
+
+Conductor.card({
+  initializeDOM: function() {
+    ok(rendered===false, "initializeDOM is called before rendering the first time");
+  },
+
+  render: function(intent) {
+    rendered = true;
+  }
+});
+

--- a/test/tests/conductor_test.js
+++ b/test/tests/conductor_test.js
@@ -101,4 +101,77 @@ test("cards have a promise resolved when the card is activated", function() {
   card.appendTo(qunitFixture);
 });
 
+test("A child card can require files through his parent", function() {
+  expect(1);
+  stop();
+
+  var conductor = new Conductor({ testing: true }),
+      card;
+
+  card = conductor.load("/test/fixtures/child/require_parent_card.js");
+
+  card.appendTo(qunitFixture);
+});
+
+// Better way to test if no new services were declared?
+// this doesn't seem to be enough
+test("A card with child cards loads the needed services", function() {
+  expect(1);
+  stop();
+
+  var conductor = new Conductor({ testing: true }),
+      card;
+
+  card = conductor.load("/test/fixtures/child/service_parent_card.js");
+
+  card.appendTo(qunitFixture);
+});
+
+test("A card with child cards loads without new services", function() {
+  expect(4);
+  stop();
+
+  var conductor = new Conductor({ testing: true }),
+      card;
+
+  card = conductor.load("/test/fixtures/child/no_service_parent_card.js");
+  card.appendTo(qunitFixture);
+});
+
+test("A card with child cards can load without defining `loadDataForChildCards`", function() {
+  expect(3);
+  stop();
+
+  var conductor = new Conductor({ testing: true }),
+      card;
+
+  card = conductor.load("/test/fixtures/child/no_custom_data_parent_card.js");
+  card.appendTo(qunitFixture);
+});
+
+test("A card with child cards calls `loadDataForChildCards` if available before loading the child cards", function() {
+  expect(3);
+  stop();
+
+  var conductor = new Conductor({ testing: true }),
+      parentCardUrl = "/test/fixtures/child/custom_data_parent_card.js",
+      card;
+
+  conductor.loadData(parentCardUrl, 1, "food for cards");
+  card = conductor.load(parentCardUrl, 1);
+  card.appendTo(qunitFixture);
+});
+
+test("A card with child cards loads the data and the associated card", function() {
+  expect(3);
+  stop();
+
+  var conductor = new Conductor({ testing: true }),
+      parentCardUrl = "/test/fixtures/child/config_data_parent_card.js",
+      card;
+
+  card = conductor.load(parentCardUrl, 1);
+  card.appendTo(qunitFixture);
+});
+
 })();

--- a/test/tests/render_test.js
+++ b/test/tests/render_test.js
@@ -40,4 +40,17 @@ test("The render method on a card is always invoked after activate", function() 
   });
 });
 
+test("A card can initialize the DOM before rendering the first time", function() {
+  expect(1);
+  var card = conductor.load('/test/fixtures/render/initialize_dom_card.js');
+
+  stop();
+
+  card.appendTo('#qunit-fixture').then(function() {
+    card.render('thumbnail');
+    card.render('thumbnail');
+    start();
+  });
+});
+
 })();


### PR DESCRIPTION
```
 A card can contain other cards.

 `childCards` is an array of objects describing the differents cards. The accepted attributes are:
 * `url` {String} the url of the card
 * `id` {String} a unique identifier for this instance (per type)
 * `options` {Object} Options passed to `Conductor.load` (optional)
 * `data` {Object} passed to `Conductor.loadData`

 Example:

    Conductor.card({
      childCards: [
        { url: '../cards/survey', id: 1 , options: {}, data: '' }
      ]
    });

 Any `Conductor.Oasis.Service` needed for a child card can be simply declared with the `services` attribute
 A card can contain other cards.

 Example:

    Conductor.card({
      services: {
        survey: SurveyService
      },
      childCards: [
        {url: 'survey', id: 1 , options: {capabilities: ['survey']} }
      ]
    });

 `loadDataForChildCards` can be defined when a child card needs data passed to the parent card.

 Once `initializeChildCards` has been called, the loaded card can be accessed through the `childCards` attribute.

 Example:

    var card = Conductor.card({
      childCards: [
        { url: '../cards/survey', id: 1 , options: {}, data: '' }
      ]
    });

    var surveyCard = card.childCards[0].card;
```
