### PR TITLE
Fix relative path loading.

### DIFF
--- a/example/cards/ad-playlist/card.js
+++ b/example/cards/ad-playlist/card.js
@@ -1,4 +1,4 @@
-Conductor.require('/example/libs/jquery-1.9.1.js');
+Conductor.require('../../libs/jquery-1.9.1.js');
 
 var AdCardUrl = '../cards/ad/card.js';
 

--- a/example/cards/ad/card.js
+++ b/example/cards/ad/card.js
@@ -1,5 +1,5 @@
-Conductor.require('/example/libs/jquery-1.9.1.js');
-Conductor.requireCSS('/example/cards/ad/style.css');
+Conductor.require('../../libs/jquery-1.9.1.js');
+Conductor.requireCSS('style.css');
 
 var VideoService = Conductor.Oasis.Service.extend({
   initialize: function (port) {

--- a/example/cards/slot_machine/card.js
+++ b/example/cards/slot_machine/card.js
@@ -1,10 +1,10 @@
 /*global Handlebars*/
 
-Conductor.require('/example/libs/jquery-1.9.1.js');
-Conductor.require('/example/libs/handlebars-1.0.0-rc.3.js');
-Conductor.require('/example/libs/jquery.jSlots.js');
-Conductor.require('/example/libs/jquery.easing.1.3.js');
-Conductor.requireCSS('/example/cards/slot_machine/style.css');
+Conductor.require('../../libs/jquery-1.9.1.js');
+Conductor.require('../../libs/handlebars-1.0.0-rc.3.js');
+Conductor.require('../../libs/jquery.jSlots.js');
+Conductor.require('../../libs/jquery.easing.1.3.js');
+Conductor.requireCSS('style.css');
 
 var dashboardTemplate = '<div id="chances"></div><button id="play">Play Now</button>';
 var playTemplate =  '<div id="chances"></div><div id="drawing" class="fancy"></div><input type="button" id="spin" value="Spin!"></div><div id="getCoins"><button>{{insertCoinsLabel}}</button><span>for another chance to win</span></div>';

--- a/example/cards/superbowl/card.js
+++ b/example/cards/superbowl/card.js
@@ -1,4 +1,4 @@
-Conductor.require('/example/libs/jquery-1.9.1.js');
+Conductor.require('../../libs/jquery-1.9.1.js');
 
 var AdPlaylistCardUrl = '../cards/ad-playlist/card.js';
 var SlotMachineCardUrl = '../cards/slot_machine/card.js';

--- a/example/cards/survey/card.js
+++ b/example/cards/survey/card.js
@@ -1,7 +1,7 @@
 /*global Handlebars*/
 
-Conductor.require('/example/libs/jquery-1.9.1.js');
-Conductor.require('/example/libs/handlebars-1.0.0-rc.3.js');
+Conductor.require('../../libs/jquery-1.9.1.js');
+Conductor.require('../../libs/handlebars-1.0.0-rc.3.js');
 
 var defaultTemplate = '<div><form>{{#each grades}}<input type="radio" name="survey" value="{{this}}">{{this}}</br>{{/each}}<input id="vote" type="button" value="Vote"></div>';
 var voteResultTemplate = 'Your rating: {{vote}} <button id="changeVote">Change</button></div>';

--- a/example/cards/video/card.js
+++ b/example/cards/video/card.js
@@ -1,7 +1,7 @@
-Conductor.require('/example/libs/jquery-1.9.1.js');
+Conductor.require('../../libs/jquery-1.9.1.js');
 // Youtube doesn't allow iframe_api via CORS
 //Conductor.require('https://www.youtube.com/iframe_api');
-Conductor.requireCSS('/example/cards/video/style.css');
+Conductor.requireCSS('style.css');
 
 var card = Conductor.card({
   consumers: {

--- a/example/playground/js/playground-card.js
+++ b/example/playground/js/playground-card.js
@@ -56,8 +56,6 @@
       }).data('card', card);
 
       card.appendTo($card.find('.card')[0]).then(function() {
-        //card.sandbox.el.seamless = true;
-
         card.render('thumbnail', {
           width: 600,
           height: 600

--- a/lib/conductor/card.js
+++ b/lib/conductor/card.js
@@ -1,3 +1,5 @@
+/*global PathUtils */
+
 (function() {
   var requiredUrls = [],
       requiredCSSUrls = [],
@@ -130,7 +132,20 @@
 
       if(this.childCards) {
         this.conductor = new Conductor();
-        this.conductor.services.xhr = Conductor.MultiplexService.extend({ upstream: this.consumers.xhr });
+        this.conductor.services.xhr = Conductor.MultiplexService.extend({
+          upstream: this.consumers.xhr,
+          transformRequest: function (requestEventName, data) {
+            var base = this.sandbox.options.url;
+            if (requestEventName === 'get') {
+              data.args = data.args.map(function (resourceUrl) {
+                var url = PathUtils.cardResourceUrl(base, resourceUrl);
+                return PathUtils.cardResourceUrl(document.baseURI, url);
+              });
+            }
+
+            return data;
+          }
+        });
 
         // A child card may not need new services
         if( this.services ) {

--- a/lib/services/multiplex_service.js
+++ b/lib/services/multiplex_service.js
@@ -40,13 +40,15 @@ Conductor.MultiplexService = Conductor.Oasis.Service.extend({
     }, this);
   },
 
-  propagateEvent: function (eventName, data) {
+  propagateEvent: function (eventName, _data) {
+    var data = (typeof this.transformEvent === 'function') ? this.transformEvent(eventName, _data) : _data;
     this.upstream.send(eventName, data);
   },
 
-  propagateRequest: function (eventName, data) {
+  propagateRequest: function (eventName, _data) {
     var requestEventName = eventName.substr("@request:".length),
         port = this.upstream.port,
+        data = (typeof this.transformRequest === 'function') ? this.transformRequest(requestEventName, _data) : _data,
         requestId = data.requestId,
         args = data.args,
         self = this;

--- a/lib/services/xhr_service.js
+++ b/lib/services/xhr_service.js
@@ -1,8 +1,11 @@
+/*global PathUtils */
+
 Conductor.XHRService = Conductor.Oasis.Service.extend({
   requests: {
     get: function(promise, url) {
       var xhr = new XMLHttpRequest(),
-          absoluteURL = this.expandPath( url );
+          resourceUrl = PathUtils.cardResourceUrl(this.sandbox.options.url, url);
+
       xhr.onload = function(a1, a2, a3, a4) {
         if (this.status === 200) {
           promise.resolve(this.responseText);
@@ -10,20 +13,8 @@ Conductor.XHRService = Conductor.Oasis.Service.extend({
           promise.reject({status: this.status});
         }
       };
-      xhr.open("get", absoluteURL, true);
+      xhr.open("get", resourceUrl, true);
       xhr.send();
     }
-  },
-
-  expandPath: function(url){
-    var loc = this.sandbox.options.url;
-
-    loc = loc.substring(0, loc.lastIndexOf('/'));
-
-    while (/^\.\./.test(url)){
-      loc = loc.substring(0, loc.lastIndexOf('/'));
-      url= url.substring(3);
-    }
-    return loc + '/' + url;
   }
 });

--- a/lib/utils/path.js
+++ b/lib/utils/path.js
@@ -1,0 +1,31 @@
+var PathUtils = window.PathUtils = {
+  dirname: function (path) {
+    return path.substring(0, path.lastIndexOf('/'));
+  },
+
+  expandPath: function (path) {
+    var parts = path.split('/');
+    for (var i = 0; i < parts.length; ++i) {
+      if (parts[i] === '..') {
+        for (var j = i-1; j >= 0; --j) {
+          if (parts[j] !== undefined) {
+            parts[i] = parts[j] = undefined;
+            break;
+          }
+        }
+      }
+    }
+    return parts.filter(function (part) { return part !== undefined; }).join('/');
+  },
+
+  cardResourceUrl: function(baseUrl, resourceUrl) {
+    var url;
+    if (/^((http(s?):)|\/)/.test(resourceUrl)) {
+      url = resourceUrl;
+    } else {
+      url = PathUtils.dirname(baseUrl) + '/' + resourceUrl;
+    }
+
+    return PathUtils.expandPath(url);
+  }
+};

--- a/test/fixtures/alert2.js
+++ b/test/fixtures/alert2.js
@@ -1,0 +1,2 @@
+ok(true, "The request was transformed");
+ok(true, "The request was transformed");

--- a/test/fixtures/child/require_absolute_child_card.js
+++ b/test/fixtures/child/require_absolute_child_card.js
@@ -1,0 +1,7 @@
+Conductor.require("/test/fixtures/alert.js");
+
+Conductor.card({
+  activate: function() {
+    start();
+  }
+});

--- a/test/fixtures/child/send_event_to_be_transformed_card.js
+++ b/test/fixtures/child/send_event_to_be_transformed_card.js
@@ -1,0 +1,6 @@
+Conductor.card({
+  activate: function () {
+    this.consumers.assertion.send('go', 'data');
+    start();
+  }
+});

--- a/test/fixtures/composite_event_transforming_card.js
+++ b/test/fixtures/composite_event_transforming_card.js
@@ -1,0 +1,15 @@
+Conductor.card({
+  activate: function () {
+    ok(true, "Card was activated");
+    start();
+
+    var conductor = new Conductor({ testing: true });
+    conductor.services.assertion = Conductor.MultiplexService.extend({
+      upstream: this.consumers.assertion,
+      transformEvent: function (eventName, data) {
+        return "transformedData";
+      }
+    });
+    conductor.load("/test/fixtures/child/send_event_to_be_transformed_card.js");
+  }
+});

--- a/test/fixtures/composite_request_transforming_card.js
+++ b/test/fixtures/composite_request_transforming_card.js
@@ -1,0 +1,16 @@
+Conductor.card({
+  activate: function () {
+    ok(true, "Card was activated");
+    start();
+
+    var conductor = new Conductor({ testing: true });
+    conductor.services.xhr = Conductor.MultiplexService.extend({
+      upstream: this.consumers.xhr,
+      transformRequest: function (requestEvent, data) {
+        data.args[0] = "alert2.js";
+        return data;
+      }
+    });
+    conductor.load("/test/fixtures/load_card.js");
+  }
+});

--- a/test/fixtures/require_absolute_card.js
+++ b/test/fixtures/require_absolute_card.js
@@ -1,0 +1,5 @@
+Conductor.card({
+  childCards: [
+    {url: '/test/fixtures/child/require_absolute_child_card.js', id: 1, options: {capabilities: ['assertion']}}
+  ]
+});

--- a/test/tests/multiplex_test.js
+++ b/test/tests/multiplex_test.js
@@ -24,3 +24,35 @@ test("Multiple grandchild cards can share a child's xhr service", function() {
 
   card.appendTo(domFixture);
 });
+
+test("Multiplexed services can transform request data", function() {
+  // composite card, load card, alert2.js x 2
+  expect(4);
+
+  stop();
+  stop();
+
+  var conductor = new Conductor({ testing: true }),
+      card = conductor.load("/test/fixtures/composite_request_transforming_card.js");
+
+  card.appendTo(domFixture);
+});
+
+test("Multiplexed services can transform event data", function() {
+  // grandchild card activation & transformed data comparison
+  expect(2);
+
+  stop();
+  stop();
+
+  var conductor = new Conductor({ testing: true }),
+      card = conductor.load("/test/fixtures/composite_event_transforming_card.js");
+
+  card.then(function () {
+    card.sandbox.assertionPort.on('go', function (data) {
+      equal(data, 'transformedData', "data was transformed");
+    });
+  });
+
+  card.appendTo(domFixture);
+});


### PR DESCRIPTION
Previously relative paths for nested cards would have an effective base
URI of the topmost card.

This also expands `Conductor.MultiplexService` to support optional data
transformations for requests and events.  For example, the following is
used to transform requests in child cards so that they become absolute
URLs immediately, after which they are propagated to the containing
environment and requested directly.

``` js
 this.conductor.services.xhr = Conductor.MultiplexService.extend({
   upstream: this.consumers.xhr,
   transformRequest: function (requestEventName, data) {
     var base = this.sandbox.options.url;
     if (requestEventName === 'get') {
       data.args = data.args.map(function (resourceUrl) {
         var url = PathUtils.cardResourceUrl(base, resourceUrl);
         return PathUtils.cardResourceUrl(document.baseURI, url);
       });
     }

      return data;
   }
 });
```
