### PR TITLE
Use height service in playground.

### DIFF
--- a/dist/conductor.js-0.1.0.js
+++ b/dist/conductor.js-0.1.0.js
@@ -1832,7 +1832,7 @@ define("oasis",
 
       newStyle.innerHTML = css;
 
-      document.head.appendChild( newStyle );
+      document.head.insertBefore(newStyle, document.head.children[0]);
     }
 
     options.events.render = function(args) {

--- a/dist/conductor.js-0.1.0.js
+++ b/dist/conductor.js-0.1.0.js
@@ -1688,7 +1688,8 @@ define("oasis",
     ```
   */
   Conductor.heightConsumer = function (card) {
-    return Conductor.Oasis.Consumer.extend({ autoUpdate: true,
+    return Conductor.Oasis.Consumer.extend({
+      autoUpdate: true,
 
       initialize: function () {
         var consumer = this;
@@ -1939,15 +1940,15 @@ define("oasis",
 
   Conductor.HeightService = Conductor.Oasis.Service.extend({
     initialize: function (port) {
+      var el;
+      if (el = this.sandbox.el) {
+        Conductor.Oasis.RSVP.EventTarget.mixin(el);
+      }
       this.sandbox.heightPort = port;
     },
 
     events: {
       resize: function (data) {
-        // TODO: remove this and fix up the demo to use the height service
-        // properly
-        if (true) { return; }
-
         // height service is meaningless for DOMless sandboxes, eg sandboxed as
         // web workers.
         if (! this.sandbox.el) { return; }
@@ -1960,6 +1961,8 @@ define("oasis",
 
         el.style.width = width + "px";
         el.style.height = height + "px";
+
+        el.trigger('resize', { width: width, height: height });
       }
     }
   });

--- a/example/cards/ad-playlist/card.js
+++ b/example/cards/ad-playlist/card.js
@@ -38,6 +38,7 @@ var card = Conductor.card({
   },
 
   activate: function (data) {
+    this.consumers.height.autoUpdate = false;
     // this may need to go in loadDataForChildCards
     this.adIds = Object.keys(data);
   },

--- a/example/cards/slot_machine/card.js
+++ b/example/cards/slot_machine/card.js
@@ -33,6 +33,7 @@ var card = Conductor.card({
   renderMode: 'dashboard',
 
   activate: function(data) {
+    this.consumers.height.autoUpdate = false;
     if( data ) {
       this.coins = typeof(data.coins) === 'number' ? data.coins : this.coins;
       this.insertCoinsLabel = data.insertCoinsLabel || this.insertCoinsLabel;

--- a/example/cards/superbowl/card.js
+++ b/example/cards/superbowl/card.js
@@ -43,6 +43,10 @@ var card = Conductor.card({
     slotMachine: SlotMachineService
   },
 
+  activate: function () {
+    this.consumers.height.autoUpdate = false;
+  },
+
   loadDataForChildCards: function( data) {
     this.childCards[1].data = data;
   },

--- a/example/cards/survey/card.js
+++ b/example/cards/survey/card.js
@@ -2,6 +2,7 @@
 
 Conductor.require('../../libs/jquery-1.9.1.js');
 Conductor.require('../../libs/handlebars-1.0.0-rc.3.js');
+Conductor.requireCSS('style.css');
 
 var defaultTemplate = '<div><form>{{#each grades}}<input type="radio" name="survey" value="{{this}}">{{this}}</br>{{/each}}<input id="vote" type="button" value="Vote"></div>';
 var voteResultTemplate = 'Your rating: {{vote}} <button id="changeVote">Change</button></div>';
@@ -16,7 +17,7 @@ Conductor.card({
   renderMode: 'survey',
 
   activate: function( data ) {
-    this.self = this;
+    this.consumers.height.autoUpdate = false;
     this.compileTemplates();
   },
 

--- a/example/cards/survey/style.css
+++ b/example/cards/survey/style.css
@@ -1,0 +1,3 @@
+body {
+  padding: 8px;
+}

--- a/lib/consumers/height_consumer.js
+++ b/lib/consumers/height_consumer.js
@@ -34,7 +34,8 @@
   ```
 */
 Conductor.heightConsumer = function (card) {
-  return Conductor.Oasis.Consumer.extend({ autoUpdate: true,
+  return Conductor.Oasis.Consumer.extend({
+    autoUpdate: true,
 
     initialize: function () {
       var consumer = this;

--- a/lib/consumers/render_consumer.js
+++ b/lib/consumers/render_consumer.js
@@ -17,7 +17,7 @@ Conductor.renderConsumer = function(promise, card) {
 
     newStyle.innerHTML = css;
 
-    document.head.appendChild( newStyle );
+    document.head.insertBefore(newStyle, document.head.children[0]);
   }
 
   options.events.render = function(args) {

--- a/lib/services/height_service.js
+++ b/lib/services/height_service.js
@@ -7,15 +7,15 @@ function maxDim(element, dim) {
 
 Conductor.HeightService = Conductor.Oasis.Service.extend({
   initialize: function (port) {
+    var el;
+    if (el = this.sandbox.el) {
+      Conductor.Oasis.RSVP.EventTarget.mixin(el);
+    }
     this.sandbox.heightPort = port;
   },
 
   events: {
     resize: function (data) {
-      // TODO: remove this and fix up the demo to use the height service
-      // properly
-      if (true) { return; }
-
       // height service is meaningless for DOMless sandboxes, eg sandboxed as
       // web workers.
       if (! this.sandbox.el) { return; }
@@ -28,6 +28,8 @@ Conductor.HeightService = Conductor.Oasis.Service.extend({
 
       el.style.width = width + "px";
       el.style.height = height + "px";
+
+      el.trigger('resize', { width: width, height: height });
     }
   }
 });


### PR DESCRIPTION
The ad card no longer knows the aspect ratio of the video card's
thumbnail. Instead, it initially divides the width between the video and
survey cards and allows the video card to expand at the expense of the
survey.
