### PR TITLE
Make conductorURL configurable.

### DIFF
--- a/dist/conductor.amd.js
+++ b/dist/conductor.amd.js
@@ -5,6 +5,10 @@ define("conductor",
 
     var Conductor = function(options) {
       this.options = options || {};
+      this.conductorURL = this.options.conductorURL || 
+                          Oasis.config.oasisURL ||
+                          '/dist/conductor.js-0.2.0.js.html';
+
       this.data = {};
       this.cards = {};
       this.services = Object.create(Conductor.services);
@@ -85,7 +89,7 @@ define("conductor",
         var sandbox = Conductor.Oasis.createSandbox({
           url: url,
           capabilities: capabilities,
-          oasisURL: '/dist/conductor.js-0.2.0.js.html',
+          oasisURL: this.conductorURL,
           services: this.services
         });
 
@@ -299,7 +303,7 @@ define("conductor",
             });
 
          Any `Conductor.Oasis.Service` needed for a child card can be simply
-         declared with the `services` attribute A card can contain other cards.
+         declared with the `services` attribute.  A card can contain other cards.
 
          Example:
 

--- a/dist/conductor.js-0.2.0.js
+++ b/dist/conductor.js-0.2.0.js
@@ -2904,6 +2904,10 @@ define("oasis",
 
   var Conductor = function(options) {
     this.options = options || {};
+    this.conductorURL = this.options.conductorURL || 
+                        Oasis.config.oasisURL ||
+                        '/dist/conductor.js-0.2.0.js.html';
+
     this.data = {};
     this.cards = {};
     this.services = Object.create(Conductor.services);
@@ -2984,7 +2988,7 @@ define("oasis",
       var sandbox = Conductor.Oasis.createSandbox({
         url: url,
         capabilities: capabilities,
-        oasisURL: '/dist/conductor.js-0.2.0.js.html',
+        oasisURL: this.conductorURL,
         services: this.services
       });
 
@@ -3198,7 +3202,7 @@ define("oasis",
           });
 
        Any `Conductor.Oasis.Service` needed for a child card can be simply
-       declared with the `services` attribute A card can contain other cards.
+       declared with the `services` attribute.  A card can contain other cards.
 
        Example:
 

--- a/dist/conductor.js-0.2.0.js
+++ b/dist/conductor.js-0.2.0.js
@@ -1850,8 +1850,8 @@ define("rsvp",
   });
 
 define("oasis",
-  ["oasis/util", "oasis/message_channel", "oasis/ports", "oasis/connect", "rsvp", "oasis/logger", "oasis/state", "oasis/sandbox", "oasis/sandbox_init", "oasis/service", "oasis/iframe_adapter", "oasis/webworker_adapter"],
-  function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, RSVP, Logger, State, Sandbox, initializeSandbox, Service, iframeAdapter, webworkerAdapter) {
+  ["oasis/util", "oasis/message_channel", "oasis/ports", "oasis/connect", "rsvp", "oasis/logger", "oasis/state", "oasis/config", "oasis/sandbox", "oasis/sandbox_init", "oasis/service", "oasis/iframe_adapter", "oasis/webworker_adapter"],
+  function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, RSVP, Logger, State, configuration, Sandbox, initializeSandbox, Service, iframeAdapter, webworkerAdapter) {
     "use strict";
     var assert = __dependency1__.assert;
     var verifySandbox = __dependency1__.verifySandbox;
@@ -1905,6 +1905,8 @@ define("oasis",
     };
     Oasis.reset();
 
+    Oasis.config = configuration;
+
 
     /**
       This registers a sandbox type inside of the containing environment so that
@@ -1937,8 +1939,8 @@ define("oasis",
 
     return Oasis;
   });define("oasis/base_adapter",
-  ["oasis/util", "oasis/ports", "oasis/message_channel", "oasis/logger"],
-  function(__dependency1__, __dependency2__, __dependency3__, Logger) {
+  ["oasis/util", "oasis/ports", "oasis/message_channel", "oasis/logger", "oasis/config"],
+  function(__dependency1__, __dependency2__, __dependency3__, Logger, configuration) {
     "use strict";
     var mustImplement = __dependency1__.mustImplement;
     var handlers = __dependency2__.handlers;
@@ -1959,6 +1961,10 @@ define("oasis",
 
     BaseAdapter.prototype = {
       loadScripts: mustImplement('BaseAdapter', 'loadScripts'),
+
+      oasisURL: function(sandbox) {
+        return sandbox.options.oasisURL || configuration.oasisURL || 'oasis.js.html';
+      },
 
       createChannel: function(sandbox) {
         var channel = new PostMessageMessageChannel();
@@ -1987,6 +1993,8 @@ define("oasis",
           if (!event.data.isOasisInitialization) { return; }
 
           Logger.log("Sandbox initializing.");
+
+          configuration.oasisURL = event.data.oasisURL;
 
           receiver.removeEventListener('message', initializeOasisSandbox);
           adapter.loadScripts(event.data.base, event.data.scriptURLs);
@@ -2018,12 +2026,26 @@ define("oasis",
           isOasisInitialization: true,
           capabilities: sandbox.capabilities,
           base: getBase(),
-          scriptURLs: scriptURLs
+          scriptURLs: scriptURLs,
+          oasisURL: this.oasisURL(sandbox)
         };
       }
     }
 
     return BaseAdapter;
+  });define("oasis/config",
+  [],
+  function() {
+    "use strict";
+    /**
+      Stores Oasis configuration.  Options include:
+
+      `oasisURL` - the default URL to use for sandboxes.
+    */
+    var configuration = {
+    };
+
+    return configuration;
   });define("oasis/connect",
   ["oasis/util", "oasis/ports", "rsvp", "oasis/logger", "oasis/state", "exports"],
   function(__dependency1__, __dependency2__, RSVP, Logger, State, __exports__) {
@@ -2129,7 +2151,7 @@ define("oasis",
       initializeSandbox: function(sandbox) {
         var options = sandbox.options,
             iframe = document.createElement('iframe'),
-            oasisURL = options.oasisURL || 'oasis.js.html';
+            oasisURL = this.oasisURL(sandbox);
 
         iframe.name = sandbox.options.url;
         iframe.sandbox = 'allow-same-origin allow-scripts';
@@ -2441,8 +2463,8 @@ define("oasis",
     __exports__.handlers = handlers;
     __exports__.ports = ports;
   });define("oasis/sandbox",
-  ["oasis/util", "oasis/message_channel", "rsvp", "oasis/logger", "oasis/state", "oasis/iframe_adapter"],
-  function(__dependency1__, __dependency2__, RSVP, Logger, OasisState, iframeAdapter) {
+  ["oasis/util", "oasis/message_channel", "rsvp", "oasis/logger", "oasis/state", "oasis/config", "oasis/iframe_adapter"],
+  function(__dependency1__, __dependency2__, RSVP, Logger, State, configuration, iframeAdapter) {
     "use strict";
     var assert = __dependency1__.assert;
     var OasisPort = __dependency2__.OasisPort;
@@ -2453,7 +2475,7 @@ define("oasis",
       this.wiretaps = [];
 
       // Generic capabilities code
-      var pkg = OasisState.packages[options.url];
+      var pkg = State.packages[options.url];
 
       var capabilities = options.capabilities;
       if (!capabilities) {
@@ -2835,7 +2857,7 @@ define("oasis",
 
     var WebworkerAdapter = extend(BaseAdapter, {
       initializeSandbox: function(sandbox) {
-        var oasisURL = sandbox.options.oasisURL || 'oasis.js.html';
+        var oasisURL = this.oasisURL(sandbox);
         var worker = new Worker(oasisURL);
         sandbox.worker = worker;
         return new RSVP.Promise(function (resolve, reject) {

--- a/dist/conductor.js-0.2.0.js.html
+++ b/dist/conductor.js-0.2.0.js.html
@@ -2926,6 +2926,10 @@ define("oasis",
 
   var Conductor = function(options) {
     this.options = options || {};
+    this.conductorURL = this.options.conductorURL || 
+                        Oasis.config.oasisURL ||
+                        '/dist/conductor.js-0.2.0.js.html';
+
     this.data = {};
     this.cards = {};
     this.services = Object.create(Conductor.services);
@@ -3006,7 +3010,7 @@ define("oasis",
       var sandbox = Conductor.Oasis.createSandbox({
         url: url,
         capabilities: capabilities,
-        oasisURL: '/dist/conductor.js-0.2.0.js.html',
+        oasisURL: this.conductorURL,
         services: this.services
       });
 
@@ -3220,7 +3224,7 @@ define("oasis",
           });
 
        Any `Conductor.Oasis.Service` needed for a child card can be simply
-       declared with the `services` attribute A card can contain other cards.
+       declared with the `services` attribute.  A card can contain other cards.
 
        Example:
 
@@ -3917,7 +3921,6 @@ for (var i=0; i<elIds.length; ++i) {
 eval(code);
 </script>
 </head>
-<!--<body style="display:none;">-->
-<body>
+<body style="display:none;">
 </body>
 </html>*/

--- a/dist/conductor.js-0.2.0.js.html
+++ b/dist/conductor.js-0.2.0.js.html
@@ -1872,8 +1872,8 @@ define("rsvp",
   });
 
 define("oasis",
-  ["oasis/util", "oasis/message_channel", "oasis/ports", "oasis/connect", "rsvp", "oasis/logger", "oasis/state", "oasis/sandbox", "oasis/sandbox_init", "oasis/service", "oasis/iframe_adapter", "oasis/webworker_adapter"],
-  function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, RSVP, Logger, State, Sandbox, initializeSandbox, Service, iframeAdapter, webworkerAdapter) {
+  ["oasis/util", "oasis/message_channel", "oasis/ports", "oasis/connect", "rsvp", "oasis/logger", "oasis/state", "oasis/config", "oasis/sandbox", "oasis/sandbox_init", "oasis/service", "oasis/iframe_adapter", "oasis/webworker_adapter"],
+  function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, RSVP, Logger, State, configuration, Sandbox, initializeSandbox, Service, iframeAdapter, webworkerAdapter) {
     "use strict";
     var assert = __dependency1__.assert;
     var verifySandbox = __dependency1__.verifySandbox;
@@ -1927,6 +1927,8 @@ define("oasis",
     };
     Oasis.reset();
 
+    Oasis.config = configuration;
+
 
     /**
       This registers a sandbox type inside of the containing environment so that
@@ -1959,8 +1961,8 @@ define("oasis",
 
     return Oasis;
   });define("oasis/base_adapter",
-  ["oasis/util", "oasis/ports", "oasis/message_channel", "oasis/logger"],
-  function(__dependency1__, __dependency2__, __dependency3__, Logger) {
+  ["oasis/util", "oasis/ports", "oasis/message_channel", "oasis/logger", "oasis/config"],
+  function(__dependency1__, __dependency2__, __dependency3__, Logger, configuration) {
     "use strict";
     var mustImplement = __dependency1__.mustImplement;
     var handlers = __dependency2__.handlers;
@@ -1981,6 +1983,10 @@ define("oasis",
 
     BaseAdapter.prototype = {
       loadScripts: mustImplement('BaseAdapter', 'loadScripts'),
+
+      oasisURL: function(sandbox) {
+        return sandbox.options.oasisURL || configuration.oasisURL || 'oasis.js.html';
+      },
 
       createChannel: function(sandbox) {
         var channel = new PostMessageMessageChannel();
@@ -2009,6 +2015,8 @@ define("oasis",
           if (!event.data.isOasisInitialization) { return; }
 
           Logger.log("Sandbox initializing.");
+
+          configuration.oasisURL = event.data.oasisURL;
 
           receiver.removeEventListener('message', initializeOasisSandbox);
           adapter.loadScripts(event.data.base, event.data.scriptURLs);
@@ -2040,12 +2048,26 @@ define("oasis",
           isOasisInitialization: true,
           capabilities: sandbox.capabilities,
           base: getBase(),
-          scriptURLs: scriptURLs
+          scriptURLs: scriptURLs,
+          oasisURL: this.oasisURL(sandbox)
         };
       }
     }
 
     return BaseAdapter;
+  });define("oasis/config",
+  [],
+  function() {
+    "use strict";
+    /**
+      Stores Oasis configuration.  Options include:
+
+      `oasisURL` - the default URL to use for sandboxes.
+    */
+    var configuration = {
+    };
+
+    return configuration;
   });define("oasis/connect",
   ["oasis/util", "oasis/ports", "rsvp", "oasis/logger", "oasis/state", "exports"],
   function(__dependency1__, __dependency2__, RSVP, Logger, State, __exports__) {
@@ -2151,7 +2173,7 @@ define("oasis",
       initializeSandbox: function(sandbox) {
         var options = sandbox.options,
             iframe = document.createElement('iframe'),
-            oasisURL = options.oasisURL || 'oasis.js.html';
+            oasisURL = this.oasisURL(sandbox);
 
         iframe.name = sandbox.options.url;
         iframe.sandbox = 'allow-same-origin allow-scripts';
@@ -2463,8 +2485,8 @@ define("oasis",
     __exports__.handlers = handlers;
     __exports__.ports = ports;
   });define("oasis/sandbox",
-  ["oasis/util", "oasis/message_channel", "rsvp", "oasis/logger", "oasis/state", "oasis/iframe_adapter"],
-  function(__dependency1__, __dependency2__, RSVP, Logger, OasisState, iframeAdapter) {
+  ["oasis/util", "oasis/message_channel", "rsvp", "oasis/logger", "oasis/state", "oasis/config", "oasis/iframe_adapter"],
+  function(__dependency1__, __dependency2__, RSVP, Logger, State, configuration, iframeAdapter) {
     "use strict";
     var assert = __dependency1__.assert;
     var OasisPort = __dependency2__.OasisPort;
@@ -2475,7 +2497,7 @@ define("oasis",
       this.wiretaps = [];
 
       // Generic capabilities code
-      var pkg = OasisState.packages[options.url];
+      var pkg = State.packages[options.url];
 
       var capabilities = options.capabilities;
       if (!capabilities) {
@@ -2857,7 +2879,7 @@ define("oasis",
 
     var WebworkerAdapter = extend(BaseAdapter, {
       initializeSandbox: function(sandbox) {
-        var oasisURL = sandbox.options.oasisURL || 'oasis.js.html';
+        var oasisURL = this.oasisURL(sandbox);
         var worker = new Worker(oasisURL);
         sandbox.worker = worker;
         return new RSVP.Promise(function (resolve, reject) {

--- a/lib/conductor.js
+++ b/lib/conductor.js
@@ -2,6 +2,10 @@ import 'oasis' as Oasis;
 
 var Conductor = function(options) {
   this.options = options || {};
+  this.conductorURL = this.options.conductorURL || 
+                      Oasis.config.oasisURL ||
+                      '/dist/conductor.js-0.2.0.js.html';
+
   this.data = {};
   this.cards = {};
   this.services = Object.create(Conductor.services);
@@ -82,7 +86,7 @@ Conductor.prototype = {
     var sandbox = Conductor.Oasis.createSandbox({
       url: url,
       capabilities: capabilities,
-      oasisURL: '/dist/conductor.js-0.2.0.js.html',
+      oasisURL: this.conductorURL,
       services: this.services
     });
 

--- a/lib/conductor/card.js
+++ b/lib/conductor/card.js
@@ -109,7 +109,7 @@
         });
 
      Any `Conductor.Oasis.Service` needed for a child card can be simply
-     declared with the `services` attribute A card can contain other cards.
+     declared with the `services` attribute.  A card can contain other cards.
 
      Example:
 

--- a/test/fixtures/check_conductor_url.js
+++ b/test/fixtures/check_conductor_url.js
@@ -1,0 +1,13 @@
+Conductor.card({
+  consumers: { urlChecker: Conductor.Oasis.Consumer },
+  activate: function() {
+    var url;
+
+    if (typeof location !== 'undefined') {
+      url = location.href;
+    } else {
+      url = Conductor.prototype.conductorURL;
+    }
+    this.consumers.urlChecker.send('checkURL', url);
+  }
+});

--- a/test/fixtures/check_conductor_url_parent.js
+++ b/test/fixtures/check_conductor_url_parent.js
@@ -1,0 +1,14 @@
+Conductor.card({
+  consumers: { urlChecker: Conductor.Oasis.Consumer },
+  activate: function () {
+    var conductor = new Conductor({ testing: true });
+    conductor.services.urlChecker = Conductor.MultiplexService.extend({
+      upstream: this.consumers.urlChecker
+    });
+    conductor.load(
+      "/test/fixtures/check_conductor_url.js",
+      1,
+      { capabilities: ['urlChecker'] }
+    ).appendTo(document.body);
+  }
+});

--- a/test/tests/conductor_test.js
+++ b/test/tests/conductor_test.js
@@ -101,6 +101,52 @@ test("cards have a promise resolved when the card is activated", function() {
   card.appendTo(qunitFixture);
 });
 
+test("A custom conductorURL can be specified in `Conductor.config.conductorURL`", function() {
+  expect(1);
+  stop();
+
+  var conductor = new Conductor({
+    testing: true,
+    conductorURL: '/test/vendor/conductor-custom-url.js.html'
+  });
+  conductor.services.urlChecker = Conductor.Oasis.Service.extend({
+    events: {
+      checkURL: function (conductorURL) {
+        var expected = 'conductor-custom-url.js.html';
+        start();
+        equal(conductorURL.substring(conductorURL.length - expected.length), expected, "Cards are loaded with correct conductor url");
+      }
+    }
+  });
+  var card = conductor.load("/test/fixtures/check_conductor_url.js",
+                            1,
+                            { capabilities: ['urlChecker']});
+  card.appendTo(qunitFixture);
+});
+
+test("Child cards reuse `Conductor.config.conductorURL`", function() {
+  expect(1);
+  stop();
+
+  var conductor = new Conductor({
+    testing: true,
+    conductorURL: '/test/vendor/conductor-custom-url.js.html'
+  });
+  conductor.services.urlChecker = Conductor.Oasis.Service.extend({
+    events: {
+      checkURL: function (conductorURL) {
+        var expected = 'conductor-custom-url.js.html';
+        start();
+        equal(conductorURL.substring(conductorURL.length - expected.length), expected, "Cards are loaded with correct conductor url");
+      }
+    }
+  });
+  var card = conductor.load("/test/fixtures/check_conductor_url_parent.js",
+                            1,
+                            { capabilities: ['urlChecker']});
+  card.appendTo(qunitFixture);
+});
+
 test("A child card can require files through his parent", function() {
   expect(1);
   stop();

--- a/test/vendor/conductor-custom-url.js.html
+++ b/test/vendor/conductor-custom-url.js.html
@@ -1,0 +1,1 @@
+../../dist/conductor.js-0.2.0.js.html


### PR DESCRIPTION
```js var conductor =
 new Conductor({
   conductorURL: '/path/to/conductor.js.html'
 });

```

Nested cards default to the conductorURL of their parent.

Fix #20.
```
