### PR TITLE
Custom services can be specified when loading a card.

### DIFF
--- a/dist/conductor.amd.js
+++ b/dist/conductor.amd.js
@@ -262,7 +262,9 @@ define("conductor.js-0.2.0",
             data = datas && datas[id],
             _options = options || {},
             extraCapabilities = _options.capabilities || [],
-            capabilities = this.capabilities.slice();
+            capabilities = this.capabilities.slice(),
+            cardServices = o_create(this.services),
+            prop;
 
         capabilities.push.apply(capabilities, extraCapabilities);
 
@@ -271,11 +273,18 @@ define("conductor.js-0.2.0",
           capabilities.push('assertion');
         }
 
+        // It is possible to add services when loading the card
+        if( _options.services ) {
+          for( prop in _options.services) {
+            cardServices[prop] = _options.services[prop];
+          }
+        }
+
         var sandbox = Conductor.Oasis.createSandbox({
           url: url,
           capabilities: capabilities,
           oasisURL: this.conductorURL,
-          services: this.services
+          services: cardServices
         });
 
         sandbox.data = data;

--- a/dist/conductor.js-0.2.0.js.html
+++ b/dist/conductor.js-0.2.0.js.html
@@ -3650,7 +3650,9 @@ define("oasis",
           data = datas && datas[id],
           _options = options || {},
           extraCapabilities = _options.capabilities || [],
-          capabilities = this.capabilities.slice();
+          capabilities = this.capabilities.slice(),
+          cardServices = o_create(this.services),
+          prop;
 
       capabilities.push.apply(capabilities, extraCapabilities);
 
@@ -3659,11 +3661,18 @@ define("oasis",
         capabilities.push('assertion');
       }
 
+      // It is possible to add services when loading the card
+      if( _options.services ) {
+        for( prop in _options.services) {
+          cardServices[prop] = _options.services[prop];
+        }
+      }
+
       var sandbox = Conductor.Oasis.createSandbox({
         url: url,
         capabilities: capabilities,
         oasisURL: this.conductorURL,
-        services: this.services
+        services: cardServices
       });
 
       sandbox.data = data;

--- a/lib/conductor.js
+++ b/lib/conductor.js
@@ -87,7 +87,9 @@ Conductor.prototype = {
         data = datas && datas[id],
         _options = options || {},
         extraCapabilities = _options.capabilities || [],
-        capabilities = this.capabilities.slice();
+        capabilities = this.capabilities.slice(),
+        cardServices = o_create(this.services),
+        prop;
 
     capabilities.push.apply(capabilities, extraCapabilities);
 
@@ -96,11 +98,18 @@ Conductor.prototype = {
       capabilities.push('assertion');
     }
 
+    // It is possible to add services when loading the card
+    if( _options.services ) {
+      for( prop in _options.services) {
+        cardServices[prop] = _options.services[prop];
+      }
+    }
+
     var sandbox = Conductor.Oasis.createSandbox({
       url: url,
       capabilities: capabilities,
       oasisURL: this.conductorURL,
-      services: this.services
+      services: cardServices
     });
 
     sandbox.data = data;

--- a/test/tests/conductor_test.js
+++ b/test/tests/conductor_test.js
@@ -110,6 +110,34 @@ test("instances can add custom services", function() {
   card.appendTo(qunitFixture);
 });
 
+test("instances can add custom services when loading a card", function() {
+  stop();
+
+  var conductor = new Conductor({ testing: true }),
+      CustomService = Conductor.Oasis.Service.extend({
+        events: {
+          result: function (result) {
+            start();
+            equal(result,"success", "Custom Service received message");
+          }
+        }
+      }),
+      card;
+
+  card = conductor.load(  "/test/fixtures/custom_consumer_card.js",
+                          1,
+                          {
+                            capabilities: ['custom'],
+                            services: {
+                              custom: CustomService
+                            }
+                          });
+
+  ok(!conductor.services.custom, "The service isn't added to the default services of the conductor");
+
+  card.appendTo(qunitFixture);
+});
+
 test("A custom conductorURL can be specified in `Conductor.config.conductorURL`", function() {
   expect(1);
   stop();


### PR DESCRIPTION
``` js
conductor.load("my_card.js", 1, {
  capabilities: ['custom'],
  services: {
    custom: CustomService
  }
});
```
