### PR TITLE
Fix playground.

### DIFF
--- a/configurations/connect.js
+++ b/configurations/connect.js
@@ -63,10 +63,33 @@ module.exports = {
     }
   },
 
-  playground: {
+  playground0: {
     options: {
-      base: '',
-      port: port + 2,
+      port: port + 4,
     }
-  }
+  },
+
+  playground1: {
+    options: {
+      port: port + 5,
+    }
+  },
+
+  playground2: {
+    options: {
+      port: port + 6,
+    }
+  },
+
+  playground3: {
+    options: {
+      port: port + 7,
+    }
+  },
+
+  playground4: {
+    options: {
+      port: port + 8,
+    }
+  },
 };

--- a/doc/Tutorial.md
+++ b/doc/Tutorial.md
@@ -37,7 +37,7 @@ grunt server
 ```
 
 Now navigate to
-[http://localhost:8000/example/playground/](http://localhost:8000/example/playground/).
+[http://localhost:8004/example/playground/](http://localhost:8004/example/playground/).
 At each step of the tutorial, it is recommended that you checkout that step's
 tag, refresh the browser and open the analytics tab at the bottom of the page so
 you can see the cross-card communication.

--- a/example/cards/ad-playlist/card.js
+++ b/example/cards/ad-playlist/card.js
@@ -1,6 +1,9 @@
 Conductor.require('/vendor/jquery.js');
+Conductor.requireCSS('style.css');
 
 var AdCardUrl = '../cards/ad/card.js';
+var destinationUrl = window.location.protocol + "//" + window.location.hostname + ":" + (parseInt(window.location.port, 10) + 1);
+var conductorUrl = destinationUrl + '/conductor-0.3.0.js.html';
 
 var VideoService = Conductor.Oasis.Service.extend({
   initialize: function (port) {
@@ -37,6 +40,11 @@ var card = Conductor.card({
     video: VideoService
   },
 
+  conductorConfiguration: {
+    conductorURL: conductorUrl,
+    allowSameOrigin: true,
+  },
+
   activate: function (data) {
     this.consumers.height.autoUpdate = false;
     // this may need to go in loadDataForChildCards
@@ -44,7 +52,7 @@ var card = Conductor.card({
     for (var prop in data) {
       if ( ! data.hasOwnProperty(prop)) { continue; }
 
-      this.adIds.push(data[prop]);
+      this.adIds.push(prop);
     }
   },
 
@@ -130,7 +138,7 @@ var card = Conductor.card({
     this.render('small');
 
     if (autoplay) {
-      this.videoAdCard.then(function () {
+      this.videoAdCard.waitForLoad().then(function () {
         card.videoAdCard.sandbox.videoPort.send('play');
       });
     }

--- a/example/cards/ad-playlist/style.css
+++ b/example/cards/ad-playlist/style.css
@@ -1,4 +1,4 @@
 iframe {
-  float: left;
+  display: block;
   border: none;
 }

--- a/example/cards/ad/card.js
+++ b/example/cards/ad/card.js
@@ -1,6 +1,9 @@
 Conductor.require('/vendor/jquery.js');
 Conductor.requireCSS('style.css');
 
+var destinationUrl = window.location.protocol + "//" + window.location.hostname + ":" + (parseInt(window.location.port, 10) + 1);
+var conductorUrl = destinationUrl + '/conductor-0.3.0.js.html';
+
 var card = Conductor.card({
   consumers: {
     survey: Conductor.Oasis.Consumer,
@@ -9,7 +12,7 @@ var card = Conductor.card({
         play: function () {
           var card = this.card;
 
-          card.waitForLoad().then(function () {
+          card.waitForActivation().then(function () {
             return card.videoCard.waitForLoad();
           }).then(function () {
             card.videoCard.sandbox.videoPort.send('play');
@@ -45,6 +48,11 @@ var card = Conductor.card({
         }
       }
     })
+  },
+
+  conductorConfiguration: {
+    conductorURL: conductorUrl,
+    allowSameOrigin: true,
   },
 
   loadDataForChildCards: function(data) {

--- a/example/cards/superbowl/card.js
+++ b/example/cards/superbowl/card.js
@@ -1,7 +1,10 @@
 Conductor.require('/vendor/jquery.js');
+Conductor.requireCSS('style.css');
 
 var AdPlaylistCardUrl = '../cards/ad-playlist/card.js';
 var SlotMachineCardUrl = '../cards/slot_machine/card.js';
+var destinationUrl = window.location.protocol + "//" + window.location.hostname + ":" + (parseInt(window.location.port, 10) + 1);
+var conductorUrl = destinationUrl + '/conductor-0.3.0.js.html';
 
 var SlotMachineService = Conductor.Oasis.Service.extend({
   initialize: function (port) {
@@ -41,6 +44,11 @@ var card = Conductor.card({
   services: {
     adPlaylist: AdPlaylistService,
     slotMachine: SlotMachineService
+  },
+
+  conductorConfiguration: {
+    conductorURL: conductorUrl,
+    allowSameOrigin: true,
   },
 
   activate: function () {

--- a/example/cards/superbowl/style.css
+++ b/example/cards/superbowl/style.css
@@ -1,4 +1,5 @@
 iframe {
-  float: left;
+  display: block;
   border: none;
 }
+

--- a/example/cards/video/card.js
+++ b/example/cards/video/card.js
@@ -9,7 +9,7 @@ Conductor.card({
       events: {
         play: function () {
           var card = this.card;
-          card.waitForLoad().then(function () {
+          card.waitForActivation().then(function () {
             return card.playerDefered().promise;
           }).then(function () {
             card.player.playVideo();

--- a/example/cards/video/style.css
+++ b/example/cards/video/style.css
@@ -5,6 +5,7 @@ html, body {
 
 iframe {
   display: block;
+  border: none;
 }
 
 #thumbnail {

--- a/example/playground/js/playground.js
+++ b/example/playground/js/playground.js
@@ -1,4 +1,4 @@
-/*globals $*/
+/*globals $,RSVP*/
 
 // Pluck off the RSVP object from Conductor and
 // re-export it to the global scope.
@@ -18,11 +18,6 @@ window.Playground = {
 
     this.conductor.configure('allowSameOrigin', true);
 
-    // Wiretap the card and configure any events
-    // to be displayed in the analytics panel on
-    // screen.
-    //this.initializeAnalytics();
-
     this.initializeServices();
     this.initializeCards();
     this.initializeAnalytics();
@@ -33,7 +28,7 @@ window.Playground = {
 
     this.cardTemplate = $('.card-wrapper').hide();
 
-    this.addCard('../cards/tutorial/ad_card.js', 1, ['video', 'survey']);
+    this.addCard('../cards/superbowl/card.js', 1, []);
   }
 };
 


### PR DESCRIPTION
There were a couple of issues.
1.  Same origin support had broken our previous playground setup.  Now each card is served from its own origin. 
2.  Previously nested iframe sandboxes did not have borders in chrome because they did not match the css selector `iframe:not([seamless])`.  In Chrome 31, the seamless attribute is not being set at all, probably because sandbox is set. 
3.  There were some miscellaneous promise errors.
